### PR TITLE
chore: update copyright year in LICENSE-MIT file

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright [year] [fullname]
+Copyright 2023-2024 Ghislain MARY
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Update the copyright year in the LICENSE-MIT file to reflect the current years 2023-2024 and attribute the copyright to Ghislain MARY. This compliance with copyright standards and accurately represents the ownership of the code.