### PR TITLE
fix: update repository and homepage URLs in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "embedded-aht20"
 version = "0.1.1"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
-repository = "https://gitlab.com/ghislainmary/embedded-aht20"
+repository = "https://github.com/ghismary/embedded-aht20"
 license = "MIT OR Apache-2.0"
 description = "Platform-agnostic Rust driver for the AHT20 temperature & humidity sensor."
 documentation = "https://docs.rs/embedded-aht20/"
 readme = "README.md"
 keywords = ["temperature", "humidity", "sensor", "aht20", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-homepage = "https://gitlab.com/ghislainmary/embedded-aht20"
+homepage = "https://github.com/ghismary/embedded-aht20"
 include = ["/**/*.rs", "/Cargo.toml", "README.md"]
 edition = "2021"
 


### PR DESCRIPTION
Change the repository and homepage URLs from GitLab to GitHub to reflect the new project hosting location. This ensures that users  can access the correct resources and documentation for the embedded-aht20 driver.