### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/ghismary/embedded-aht20/compare/v0.1.2...v0.1.3) - 2024-12-02
+
+### Fixed
+
+- *(deps)* update weather-utils to version 0.2.1
+
 ## [0.1.2](https://github.com/ghismary/embedded-aht20/compare/v0.1.1...v0.1.2) - 2024-12-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-aht20"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/embedded-aht20"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `embedded-aht20`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/ghismary/embedded-aht20/compare/v0.1.2...v0.1.3) - 2024-12-02

### Fixed

- *(deps)* update weather-utils to version 0.2.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).