### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.4](https://github.com/ghismary/embedded-aht20/compare/v0.1.3...v0.1.4) - 2025-02-03
+## [0.2.0](https://github.com/ghismary/embedded-aht20/compare/v0.1.3...v0.2.0) - 2025-02-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/ghismary/embedded-aht20/compare/v0.1.3...v0.1.4) - 2025-02-03
+
+### Added
+
+- Add Github status & code coverage badges
+- Update dependencies & add tests
+
 ## [0.1.3](https://github.com/ghismary/embedded-aht20/compare/v0.1.2...v0.1.3) - 2024-12-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-aht20"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/embedded-aht20"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-aht20"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/embedded-aht20"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION


## 🤖 New release

* `embedded-aht20`: 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/ghismary/embedded-aht20/compare/v0.1.3...v0.2.0) - 2025-02-03

### Added

- Add Github status & code coverage badges
- Update dependencies & add tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).