### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/ghismary/embedded-aht20/compare/v0.2.0...v0.3.0) - 2026-06-10
+
+### Fixed
+
+- Update tests so that they can build on platforms other than Linux
+
+### Other
+
+- Improve code coverage
+- Add zed tasks
+- Update CI workflows
+- Update dependencies
+
 ## [0.2.0](https://github.com/ghismary/embedded-aht20/compare/v0.1.3...v0.2.0) - 2025-02-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-aht20"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/embedded-aht20"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `embedded-aht20`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/ghismary/embedded-aht20/compare/v0.2.0...v0.3.0) - 2026-06-10

### Fixed

- Update tests so that they can build on platforms other than Linux

### Other

- Improve code coverage
- Add zed tasks
- Update CI workflows
- Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).