### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/ghismary/embedded-aht20/compare/v0.3.0...v0.3.1) - 2026-06-12
+
+### Other
+
+- Update weather-utils dependency
+
 ## [0.3.0](https://github.com/ghismary/embedded-aht20/compare/v0.2.0...v0.3.0) - 2026-06-10
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-aht20"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/embedded-aht20"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `embedded-aht20`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/ghismary/embedded-aht20/compare/v0.3.0...v0.3.1) - 2026-06-12

### Other

- Update weather-utils dependency
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).